### PR TITLE
Implements ROLLBACK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ascendb

--- a/.scratchpad.md
+++ b/.scratchpad.md
@@ -1,0 +1,77 @@
+# Rollback approaches
+
+1. Need to revert DB to state prior to last command
+    1. backwards:
+        1. keep a stack of "undo commands"
+        2. undo last command by issuing the "opposite", e.g.
+            1. new key:    write(k,v)   -> delete(k)
+            2. update key: write(k, v1) -> write(k, v0)
+            3. delete key: delete(k)    -> write(k, v0)
+        3. for all, need to read(k) before each operation to capture state
+        4. but what if the db tracked the history of values for each key?
+            1. e.g. `map[string][]string`, where `[]string` is a stack of values
+            2. by the definition of the input format, we can't have an empty value, so `""` can be used to represent the deleted state
+            3. then just track the transactions as a history of keys, and pop as we go
+            4. catches:
+                1. what if we roll back to an empty slice?
+                2. tricky to test, requires multiple commands to test a single case
+                3. I did not include input file parsing as part of `db`, but that, or spinning it of into a separate package, would make feeding long/complex command sequence to the tests much easier
+    2. forwards:
+        1. keep a queue of commands issued
+        2. on a rollback:
+            1. replay the the commands, skipping the latest
+        3. that's potentially a lot of writes!
+        4. from the exercise brief: `Your program should run the commands in the file line by line`
+            1. so we aren't:
+                1. treating the input file as the transaction log
+                2. reading the whole file in first so we can just identify and skip rolledback commands
+                    ```
+                        WRITE key-0 val-1
+                        WRITE key-1 val-3
+                        WRITE key-2 val-4
+                      ┌─DELETE key-1
+                      │┌DELETE key-0
+                      │└ROLLBACK
+                      └─ROLLBACK
+                        WRITE key-2 val-8
+                        DELETE key-0
+                        PRINT
+                    ```
+                3. could be implemented as a stack, push commands on and pop when you get to a rollback
+                4. if we _did_ go down this road, could also check for keys deleted and never re-written
+                5. but this is a stream process, not batch!
+
+
+
+
+
+
+
+
+# watch out!
+
+* what if we start with a ROLLBACK?
+* a DELETE on an empty should be fine, what if we followed that with a ROLLBACK?
+    * well, we should only be able to rollback successful db writes/deletes, otherwise what does that even mean?
+    * so rollback need to know the difference between a delete that was on a real key (which we track by considering its value to be `""`, and a DELETE that was _NOT_ preceeded by a WRITE)
+* commands should be process as a stream, not a batch, so we can't optimize along those lines.
+* input is "whitespace delimited" so `""` is not a valid key OR value
+
+# Enhancements
+
+* print out live updates to db
+* save db to disk on a hard exit, give options to restore/resume
+    * interrupt or input file typo
+        1. log error
+        2. write out "restore file" containing:
+            * input file name
+            * line number of error/last line processes
+            * db dump
+        3. on next run:
+            1. check for new "-restore" flag pointing to backup file
+            2. parse file to rebuild db
+            3. open logged input file and pick up where left off
+            4. note: no history is preserved, it's possible that subsequent commands could try to rollback to before the restore
+            5. actually, go prints out structs very nicely, we _could_  write out the entire state and history of the db and then parse it back in
+* setup CI/CD
+* 

--- a/.scratchpad.md
+++ b/.scratchpad.md
@@ -74,4 +74,4 @@
             4. note: no history is preserved, it's possible that subsequent commands could try to rollback to before the restore
             5. actually, go prints out structs very nicely, we _could_  write out the entire state and history of the db and then parse it back in
 * setup CI/CD
-* 
+* refactor to make it easy to test large inputs

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,10 @@ GO_RUN     = ${GO_TOOL} run
 GO_INSTALL = ${GO_TOOL} install
 
 # Project-specific variables
-BINARY_NAME = memdb
-INPUT_FILE  = input-1.log
+BINARY_NAME  = memdb
+INPUT_FILE   = input-1.log
+SANITY_FILE  = sanity.log
+
 
 # Targets
 run:
@@ -29,6 +31,9 @@ test:
 check:
 	${GO_VERSION}
 	${GO_ENV}
+
+sanity: clean check build
+	./${BINARY_NAME} ${SANITY_FILE} -v
 
 clean:
 	rm -f ${BINARY_NAME}

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GO_RUN     = ${GO_TOOL} run
 GO_INSTALL = ${GO_TOOL} install
 
 # Project-specific variables
-BINARY_NAME  = memdb
+BINARY_NAME  = ascendb
 INPUT_FILE   = input-1.log
 SANITY_FILE  = sanity.log
 

--- a/db/db.go
+++ b/db/db.go
@@ -4,14 +4,11 @@ import (
 	"fmt"
 )
 
-// Command is a single database command
-type command []string
-
 // Database is an in-memory KV store.
 // It tracks the current state and the transaction history.
 type Database struct {
-	state   map[string]string
-	history []command
+	state   map[string][]string
+	history []string
 }
 
 // DatabaseError handles errors specific to db operations.
@@ -27,37 +24,58 @@ const ErrMissingKey = DatabaseError("key not present")
 // New in-memory database.
 func New() (d *Database) {
 	return &Database{
-		state:   make(map[string]string),
-		history: make([]command, 0),
+		state:   make(map[string][]string),
+		history: make([]string, 1),
 	}
 }
 
 // Write the value `v` to the database under key `k`.
-func (d Database) Write(k, v string) {
-	d.state[k] = v
+func (d *Database) Write(k, v string) {
+	d.state[k] = append(d.state[k], v)
+	d.history = append(d.history, k)
 }
 
 // Read the value stored under key `k`. Returns an error message if the key is missing.
-func (d Database) Read(k string) (v string, err error) {
-	v, ok := d.state[k]
+func (d *Database) Read(k string) (v string, err error) {
+	vals, ok := d.state[k]
 	if !ok {
+		return "", ErrMissingKey
+	}
+
+	l := len(vals)
+	if l < 1 {
+		return "", ErrMissingKey
+	}
+
+	v = vals[len(vals)-1]
+	if v == "" {
 		err = ErrMissingKey
 	}
 	return v, err
 }
 
 // Delete the key `k` from the database.
-func (d Database) Delete(k string) {
-	delete(d.state, k)
+func (d *Database) Delete(k string) {
+	d.Write(k, "")
 }
 
 // Print the current state of the database.
-func (d Database) Print() {
+func (d *Database) Print() {
 	for k, v := range d.state {
-		fmt.Println(k, v)
+		latestValue := v[len(v)-1]
+		if latestValue != "" {
+			fmt.Println(k, latestValue)
+		}
 	}
 }
 
 // Rollback the database back to its state prior to the most recent command.
-func (d Database) Rollback() {
+// Pops most recently accessed key off of history stack, and then pops that latest value off of that key's stack.
+func (d *Database) Rollback() {
+	l := len(d.history) - 1
+	lastCommand := d.history[l]
+	d.history = d.history[:l]
+
+	l = len(d.state[lastCommand]) - 1
+	d.state[lastCommand] = d.state[lastCommand][:l]
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -20,16 +20,16 @@ func TestReadAndWrite(t *testing.T) {
 	}
 
 	d := New()
-	for _, tt := range tests {
+	for i, tt := range tests {
 
 		d.Write(tt.writeKey, tt.writeVal)
 		val, err := d.Read(tt.readKey)
 		if err != tt.expected {
-			t.Errorf("read error '%v', expected '%v'", err, tt.expected)
+			t.Errorf("read error '%v', expected '%v' for test case [%d] %v", err, tt.expected, i, tt)
 			continue
 		}
 		if val != tt.readVal {
-			t.Errorf("read value '%s', expected '%s'", val, tt.readVal)
+			t.Errorf("read value '%s', expected '%s' for test case [%d] %v", val, tt.readVal, i, tt)
 		}
 	}
 }
@@ -43,7 +43,7 @@ func TestDelete(t *testing.T) {
 	}
 
 	d := New()
-	for _, tt := range tests {
+	for i, tt := range tests {
 
 		d.Write(tt.key, tt.val)
 		_, err := d.Read(tt.key)
@@ -55,7 +55,7 @@ func TestDelete(t *testing.T) {
 		d.Delete(tt.key)
 		_, err = d.Read(tt.key)
 		if err != tt.expected {
-			t.Errorf("read error '%v', expected '%v'", err, tt.expected)
+			t.Errorf("read error '%v', expected '%v' for test case [%d] %v", err, tt.expected, i, tt)
 		}
 	}
 }
@@ -69,7 +69,7 @@ func TestRollback(t *testing.T) {
 	}
 
 	d := New()
-	for _, tt := range tests {
+	for i, tt := range tests {
 
 		d.Write(tt.key, tt.val)
 		_, err := d.Read(tt.key)
@@ -81,7 +81,7 @@ func TestRollback(t *testing.T) {
 		d.Rollback()
 		_, err = d.Read(tt.key)
 		if err != tt.expected {
-			t.Errorf("read error '%v', expected '%v'", err, tt.expected)
+			t.Errorf("read error '%v', expected '%v' for test case [%d] %v", err, tt.expected, i, tt)
 		}
 	}
 }

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -11,11 +11,8 @@ func TestReadAndWrite(t *testing.T) {
 		expected           error
 	}{
 		{"key-0", "value-0", "key-0", "value-0", nil},
-		{"key-0", "", "key-0", "", nil},
 		{"key-0", "", "key-1", "", ErrMissingKey},
-		{"key-1", "", "key-1", "", nil},
 		{"key-1", "value-1", "key-1", "value-1", nil},
-		{"", "", "", "", nil},
 		{"key-2", "value-2", "key-2", "value-2", nil},
 	}
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -11,7 +11,7 @@ func TestReadAndWrite(t *testing.T) {
 		expected           error
 	}{
 		{"key-0", "value-0", "key-0", "value-0", nil},
-		{"key-0", "", "key-1", "", ErrMissingKey},
+		{"key-0", "", "key-1", "", ErrKeyNonexistant},
 		{"key-1", "value-1", "key-1", "value-1", nil},
 		{"key-2", "value-2", "key-2", "value-2", nil},
 	}
@@ -36,7 +36,7 @@ func TestDelete(t *testing.T) {
 		key, val string
 		expected error
 	}{
-		{"key-0", "value-0", ErrMissingKey},
+		{"key-0", "value-0", ErrKeyDeleted},
 	}
 
 	d := New()
@@ -62,7 +62,7 @@ func TestRollback(t *testing.T) {
 		key, val string
 		expected error
 	}{
-		{"key-0", "value-0", ErrMissingKey},
+		{"key-0", "value-0", ErrKeyMissing},
 	}
 
 	d := New()

--- a/main.go
+++ b/main.go
@@ -28,23 +28,19 @@ func main() {
 
 	d := db.New()
 	for fileScanner.Scan() {
-		if err != nil {
-			break
-		} else {
-			switch command := strings.Fields(fileScanner.Text()); command[0] {
-			case "WRITE":
-				d.Write(command[1], command[2])
-			case "DELETE":
-				d.Delete(command[1])
-			case "PRINT":
-				d.Print()
-			case "ROLLBACK":
-				d.Rollback()
-			case "#":
-			default:
-				fmt.Printf("unknown instruction `%s` found\n", command[0])
-				return
-			}
+		switch command := strings.Fields(fileScanner.Text()); command[0] {
+		case "WRITE":
+			d.Write(command[1], command[2])
+		case "DELETE":
+			d.Delete(command[1])
+		case "PRINT":
+			d.Print()
+		case "ROLLBACK":
+			d.Rollback()
+		case "#":
+		default:
+			fmt.Printf("unknown instruction `%s` found\n", command[0])
+			return
 		}
 	}
 	return

--- a/main.go
+++ b/main.go
@@ -9,15 +9,18 @@ import (
 	"github.com/theeddieh/ascend/db"
 )
 
+// accepts a single argument pointing to the path of the input file
+// reads file a line at a time
+// executes database commands as they are read
 func main() {
-	// this should accept a single argument on the command line
-	// pointing to the path of the input file
+
 	if len(os.Args) < 2 {
 		fmt.Printf("No filepath specified\n")
 		fmt.Printf("Usage:\n")
 		fmt.Printf("  ./memdb <path to input file>\n")
 		return
 	}
+
 	infile, err := os.Open(os.Args[1])
 	if err != nil {
 		fmt.Printf("Failed to open file: %s\n", os.Args[1])

--- a/main.go
+++ b/main.go
@@ -13,19 +13,20 @@ func main() {
 	// this should accept a single argument on the command line
 	// pointing to the path of the input file
 	if len(os.Args) < 2 {
-		fmt.Println("No filepath specified")
+		fmt.Printf("No filepath specified\n")
+		fmt.Printf("Usage:\n")
+		fmt.Printf("  ./memdb <path to input file>\n")
 		return
 	}
 	infile, err := os.Open(os.Args[1])
 	if err != nil {
-		fmt.Printf("Failed to open file: %s", os.Args[1])
+		fmt.Printf("Failed to open file: %s\n", os.Args[1])
 		return
 	}
 	defer infile.Close()
 	fileScanner := bufio.NewScanner(infile)
 
 	d := db.New()
-
 	for fileScanner.Scan() {
 		if err != nil {
 			break
@@ -41,7 +42,7 @@ func main() {
 				d.Rollback()
 			case "#":
 			default:
-				fmt.Println(fmt.Errorf("unknown instruction `%s` found", command[0]))
+				fmt.Printf("unknown instruction `%s` found\n", command[0])
 				return
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,11 @@ func main() {
 		return
 	}
 
+	var debug bool
+	if len(os.Args) > 2 && os.Args[2] == "-v" {
+		debug = true
+	}
+
 	infile, err := os.Open(os.Args[1])
 	if err != nil {
 		fmt.Printf("Failed to open file: %s\n", os.Args[1])
@@ -38,6 +43,9 @@ func main() {
 			d.Delete(command[1])
 		case "PRINT":
 			d.Print()
+			if debug {
+				fmt.Println("-----------")
+			}
 		case "ROLLBACK":
 			d.Rollback()
 		case "#":

--- a/readme.md
+++ b/readme.md
@@ -5,8 +5,8 @@
 We'd like to see how you would finish this coding exercise.
 The goal is to implement a basic in-memory nosql database.
 
-Each line of the input file contains an instruction followed by a set of whitespace delimited arguments.
-Your program should run the commands in the file line by line and print the final database state to standard out.
+Each line of the input file contains an instruction followed by a set of *whitespace delimited arguments*.
+Your program should run the commands in the file *line by line* and print the final database state to standard out.
 
 You can choose to finish the exercise in any language you prefer.
 We have started a portion of the script in golang, as this is the primary language you can expect to work on here at Ascend.

--- a/sanity.log
+++ b/sanity.log
@@ -1,0 +1,38 @@
+# will rolling back an empty db pass?
+ROLLBACK
+# can we write?
+WRITE wrote this
+PRINT
+# can we overwrite?
+WRITE wrote this-again
+PRINT
+# can we delete?
+WRITE wrote keep-this
+WRITE delete this-next
+PRINT
+WRITE wrote kept-this
+WRITE delete rolled-back
+DELETE delete
+PRINT
+# can we delete...nothing?
+DELETE key-2
+PRINT
+# can we rollback?
+ROLLBACK
+WRITE rolled-back delete
+PRINT
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+ROLLBACK
+WRITE rolled-back everything-else
+PRINT


### PR DESCRIPTION
For issue #1.

Rollback implemented by updating the internal representation of the database to:
```
type Database struct {
	state   map[string][]string
	history []string
}
```

When a key is successfully written or deleted, its name is pushed on to the stack `Database.history`.
The changing values for the key are then pushed onto a separate stack, `Database.state[key]` .
A rollback require two pops, one to get the key and another to pop its latest value. 


